### PR TITLE
Improved wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ dump-shapes = ["rquickjs-core/dump-shapes"]
 dump-module-resolve = ["rquickjs-core/dump-module-resolve"]
 dump-promise = ["rquickjs-core/dump-promise"]
 dump-read-object = ["rquickjs-core/dump-read-object"]
+no-free = ["rquickjs-core/no-free"]
 
 # Enable compilation tests
 compile-tests = ["rquickjs-core/compile-tests"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -101,6 +101,7 @@ dump-shapes = ["rquickjs-sys/dump-shapes"]
 dump-module-resolve = ["rquickjs-sys/dump-module-resolve"]
 dump-promise = ["rquickjs-sys/dump-promise"]
 dump-read-object = ["rquickjs-sys/dump-read-object"]
+no-free = ["rquickjs-sys/no-free"]
 
 # Enable compilation tests
 compile-tests = []

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -43,3 +43,7 @@ dump-shapes = []
 dump-module-resolve = []
 dump-promise = []
 dump-read-object = []
+
+# Enables a custom patch that no-ops when freeing values.
+# Useful in WebAssembly contexts where programs are short lived.
+no-free = []

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -95,6 +95,7 @@ fn main() {
 
     let features = [
         "bindgen",
+        "no-free",
         "update-bindings",
         "dump-bytecode",
         "dump-gc",
@@ -180,6 +181,10 @@ fn main() {
             .expect("Unable to copy source; try 'git submodule update --init'");
     }
     fs::copy("quickjs.bind.h", out_dir.join("quickjs.bind.h")).expect("Unable to copy source");
+
+    if env::var(feature_to_cargo("no_free")).is_ok() {
+        patch_files.push("no_free.patch");
+    }
 
     // applying patches
     for file in &patch_files {

--- a/sys/patches/no_free.patch
+++ b/sys/patches/no_free.patch
@@ -1,0 +1,12 @@
+diff --git a/quickjs.c b/quickjs.c
+index e8fdd8a..48cb34b 100644
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -5517,6 +5517,7 @@ static void free_zero_refcount(JSRuntime *rt)
+ /* called with the ref_count of 'v' reaches zero. */
+ void __JS_FreeValueRT(JSRuntime *rt, JSValue v)
+ {
++    return;
+     uint32_t tag = JS_VALUE_GET_TAG(v);
+ 
+ #ifdef DUMP_FREE


### PR DESCRIPTION
This commit adds a feature `no-free` and a patch that makes QuickJS' `__JS_FreeValueRT` be a noop. 

This is useful in certain short-lived Wasm programs, where freeing values in the runtime itself is not a concern and it can be assumed that the Wasm runtime will clean up any memory by recycling the Instance's memory at the end of the execution.